### PR TITLE
Fix nvidia-drivers-loaders service activation time

### DIFF
--- a/nvidia-gpu-installer.sh
+++ b/nvidia-gpu-installer.sh
@@ -438,7 +438,8 @@ EOF
   cat <<-EOF > /etc/systemd/system/nvidia-drivers-loader.service
 [Unit]
 Description=auto loader of nvidia drivers
-Before=local-fs.target
+Before=sysinit.target
+After=systemd-modules-load.service
 DefaultDependencies=no
 Conflicts=shutdown.target
 
@@ -560,6 +561,9 @@ fix()
       chmod +x "$f"
     fi
   done
+
+  echo "fix nvidia-drivers-loader service"
+  sed -i 's/Before=local-fs.*/Before=sysinit.target\nAfter=systemd-modules-load.service/' /etc/systemd/system/nvidia-drivers-loader.service
   echo "Fix... DONE"
 }
 


### PR DESCRIPTION
With the kernel that the i2c_core built in Module format, insmod nvidia maybe
happend before i2c_core is inserted, leading to the error 'Unknown symbol
i2c_add_adapter'.  So we need to do nvidia insertion after systemd-modules-load.service